### PR TITLE
ci(release): get-projects needs permissions to be set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   get-projects:
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/detect-changed-projects.yml
 
   create-pull-request:


### PR DESCRIPTION
They must be added by the caller for reusable workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actionsワークフローの権限設定を明示的に追加しました（contents: read、pull-requests: read）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->