### PR TITLE
ci(release): Add needs for get-projects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   get-projects:
+    needs: detect-release-commit
+    if: ${{ needs.detect-release-commit.outputs.is-release-commit == 'false' }}
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
It's required to detect release commits.