### PR TITLE
ci(renovate): Ignore the PoC directory in infra [ASR-44]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>shiron-dev/renovate-config"]
+  "extends": ["github>shiron-dev/renovate-config"],
+  "ignorePaths": ["infra/poc/**"]
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renovateの設定を更新し、"infra/poc"ディレクトリ以下をアップデート対象から除外しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->